### PR TITLE
make RestBuilder public

### DIFF
--- a/hadoop-mini-clusters-hbase/src/main/java/com/github/sakserv/minicluster/impl/HbaseRestLocalCluster.java
+++ b/hadoop-mini-clusters-hbase/src/main/java/com/github/sakserv/minicluster/impl/HbaseRestLocalCluster.java
@@ -93,7 +93,7 @@ class HbaseRestLocalCluster implements MiniCluster {
         this.builder = builder.builder;
     }
 
-    static class RestBuilder {
+    public static class RestBuilder {
         private Integer hbaseRestPort;
         private Integer hbaseRestInfoPort;
         private String hbaseRestHost;


### PR DESCRIPTION
Because RestBuilder is package protected, activeRestGateway can not be configured.

Sorry for the bug...

Regards,

Khanh