### PR TITLE
#38: Adding proxy support for oozie share lib download

### DIFF
--- a/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/http/HttpUtils.java
+++ b/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/http/HttpUtils.java
@@ -19,6 +19,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.slf4j.Logger;
@@ -28,11 +32,24 @@ public class HttpUtils {
 
     // Logger
     private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
+    private static final String PROXY_PROPERTY_NAME = "HTTP_PROXY";
+    private static final String ALL_PROXY_PROPERTY_NAME = "ALL_PROXY";
 
     public static void downloadFileWithProgress(String fileUrl, String outputFilePath) throws IOException {
         String fileName =  fileUrl.substring(fileUrl.lastIndexOf('/') + 1);
         URL url = new URL(fileUrl);
-        HttpURLConnection httpURLConnection = (HttpURLConnection) (url.openConnection());
+        HttpURLConnection httpURLConnection;
+        
+        //Check if system proxy is set
+      	Proxy proxySettings = returnProxyIfEnabled();
+      	if(proxySettings!=null)
+      	{
+      		httpURLConnection = (HttpURLConnection) (url.openConnection(proxySettings));
+      	}
+      	else
+      	{
+      		httpURLConnection = (HttpURLConnection) (url.openConnection());
+      	}
         long fileSize = httpURLConnection.getContentLength();
 
         // Create the parent output directory if it doesn't exis
@@ -64,5 +81,54 @@ public class HttpUtils {
         bufferedOutputStream.close();
         bufferedInputStream.close();
     }
+    
+	private static Proxy returnProxyIfEnabled() {
+		LOG.debug("returnProxyIfEnabled() start!!");
+		String proxyURLString = System.getProperty(PROXY_PROPERTY_NAME) != null ? System.getProperty(PROXY_PROPERTY_NAME)
+				: System.getProperty(PROXY_PROPERTY_NAME.toLowerCase());
+		String allproxyURLString = System.getProperty(ALL_PROXY_PROPERTY_NAME) != null
+				? System.getProperty(ALL_PROXY_PROPERTY_NAME) : System.getProperty(ALL_PROXY_PROPERTY_NAME.toLowerCase());
+		//Pick PROXY URL from two widely used system properties
+		String finalProxyString = proxyURLString != null ? proxyURLString : allproxyURLString;
+
+		URL proxyURL = null;
+		
+		try {
+			//If Proxy URL starts with HTTP then use HTTP PROXY settings
+			if (finalProxyString != null && finalProxyString.toLowerCase().startsWith("http")) {
+				// Basic method to validate proxy URL is correct or not.
+				proxyURL = returnParsedURL(finalProxyString);
+				LOG.debug("protocol of proxy used is: " + proxyURL.getProtocol());
+				return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyURL.getHost(), proxyURL.getPort()));
+			} //If Proxy URL starts with no protocol then assume it is HTTP
+			else if (finalProxyString != null && !finalProxyString.contains("://")
+					&& finalProxyString.split(":").length == 2) {
+				LOG.debug("protocol of proxy used is: http default");
+				proxyURL = returnParsedURL("http://".concat(finalProxyString));
+				return proxyURL !=null ? new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyURL.getHost(), proxyURL.getPort())) : null;
+			} //If Proxy URL starts with SOCKS4 or SOCKS5 protocol then go for SOCKS settings
+			else if (finalProxyString != null && finalProxyString.toLowerCase().startsWith("sock")
+					&& finalProxyString.split("://").length == 2) {
+				LOG.debug("protocol of proxy used is: Socks");
+				proxyURL = returnParsedURL("http://".concat(finalProxyString.split("://")[1]));
+				return proxyURL !=null ? new Proxy(Proxy.Type.SOCKS, new InetSocketAddress(proxyURL.getHost(), proxyURL.getPort())) : null;
+			}
+		} catch (MalformedURLException | URISyntaxException mUE) {
+			LOG.error("Can not configure Proxy because URL {} is incorrect: " + mUE, finalProxyString);
+		}
+
+		return null;
+	}
+
+	private static URL returnParsedURL(String urlString) throws MalformedURLException, URISyntaxException 
+	{
+		if (urlString != null) {
+			URL url = new URL(urlString);
+			url.toURI();
+			LOG.info("System has been set to use proxy. Hence, configuring proxy URL: {}", urlString);
+			return url;
+		}
+		return null;
+	}
 
 }

--- a/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/http/HttpUtils.java
+++ b/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/http/HttpUtils.java
@@ -82,8 +82,10 @@ public class HttpUtils {
         bufferedInputStream.close();
     }
     
-	private static Proxy returnProxyIfEnabled() {
+	public static Proxy returnProxyIfEnabled() {
 		LOG.debug("returnProxyIfEnabled() start!!");
+		String proxyStarturl="http://";
+		
 		String proxyURLString = System.getProperty(PROXY_PROPERTY_NAME) != null ? System.getProperty(PROXY_PROPERTY_NAME)
 				: System.getProperty(PROXY_PROPERTY_NAME.toLowerCase());
 		String allproxyURLString = System.getProperty(ALL_PROXY_PROPERTY_NAME) != null
@@ -95,7 +97,7 @@ public class HttpUtils {
 		
 		try {
 			//If Proxy URL starts with HTTP then use HTTP PROXY settings
-			if (finalProxyString != null && finalProxyString.toLowerCase().startsWith("http")) {
+			if (finalProxyString != null && finalProxyString.toLowerCase().startsWith(proxyStarturl)) {
 				// Basic method to validate proxy URL is correct or not.
 				proxyURL = returnParsedURL(finalProxyString);
 				LOG.debug("protocol of proxy used is: " + proxyURL.getProtocol());
@@ -104,13 +106,13 @@ public class HttpUtils {
 			else if (finalProxyString != null && !finalProxyString.contains("://")
 					&& finalProxyString.split(":").length == 2) {
 				LOG.debug("protocol of proxy used is: http default");
-				proxyURL = returnParsedURL("http://".concat(finalProxyString));
+				proxyURL = returnParsedURL(proxyStarturl.concat(finalProxyString));
 				return proxyURL !=null ? new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyURL.getHost(), proxyURL.getPort())) : null;
 			} //If Proxy URL starts with SOCKS4 or SOCKS5 protocol then go for SOCKS settings
 			else if (finalProxyString != null && finalProxyString.toLowerCase().startsWith("sock")
 					&& finalProxyString.split("://").length == 2) {
 				LOG.debug("protocol of proxy used is: Socks");
-				proxyURL = returnParsedURL("http://".concat(finalProxyString.split("://")[1]));
+				proxyURL = returnParsedURL(proxyStarturl.concat(finalProxyString.split("://")[1]));
 				return proxyURL !=null ? new Proxy(Proxy.Type.SOCKS, new InetSocketAddress(proxyURL.getHost(), proxyURL.getPort())) : null;
 			}
 		} catch (MalformedURLException | URISyntaxException mUE) {

--- a/hadoop-mini-clusters-common/src/test/java/com/github/sakserv/minicluster/http/HttpUtilsTest.java
+++ b/hadoop-mini-clusters-common/src/test/java/com/github/sakserv/minicluster/http/HttpUtilsTest.java
@@ -1,0 +1,69 @@
+package com.github.sakserv.minicluster.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.net.Proxy;
+
+import org.junit.Test;
+
+public class HttpUtilsTest {
+
+	@Test
+	public void testReturnProxyIfProxyPropsAreSetToNull() {
+		System.clearProperty("HTTP_PROXY");
+		System.clearProperty("ALL_PROXY");
+		assertNull(HttpUtils.returnProxyIfEnabled());
+	}
+	
+	@Test
+	public void testReturnProxyIfHTTPProxyIsSet() {
+		System.setProperty("HTTP_PROXY","http://104.207.145.113:3128");
+		System.clearProperty("ALL_PROXY");
+		assertNotNull(HttpUtils.returnProxyIfEnabled());
+		assertEquals("/104.207.145.113:3128",HttpUtils.returnProxyIfEnabled().address().toString());
+		assertEquals(Proxy.Type.HTTP,HttpUtils.returnProxyIfEnabled().type());
+	}
+	
+	@Test
+	public void testReturnProxyIfSOCKProxyIsSet() {
+		System.setProperty("HTTP_PROXY","sock5://207.98.253.161:10200");
+		System.clearProperty("ALL_PROXY");
+		assertNotNull(HttpUtils.returnProxyIfEnabled());
+		assertEquals("/207.98.253.161:10200",HttpUtils.returnProxyIfEnabled().address().toString());
+		assertEquals(Proxy.Type.SOCKS,HttpUtils.returnProxyIfEnabled().type());
+	}
+	
+	@Test
+	public void testReturnProxyIfSOCKProxyIsSetGnomeClient() {
+		System.clearProperty("HTTP_PROXY");
+		System.setProperty("ALL_PROXY", "sock5://207.98.253.161:10200");
+		assertNotNull(HttpUtils.returnProxyIfEnabled());
+		assertEquals("/207.98.253.161:10200",HttpUtils.returnProxyIfEnabled().address().toString());
+		assertEquals(Proxy.Type.SOCKS,HttpUtils.returnProxyIfEnabled().type());
+	}
+	
+	@Test
+	public void testReturnProxyIfHTTPProxyIsSetGnomeClient() {
+		System.clearProperty("HTTP_PROXY");
+		System.setProperty("ALL_PROXY","104.207.145.113:3128");
+		assertNotNull(HttpUtils.returnProxyIfEnabled());
+		assertEquals("/104.207.145.113:3128",HttpUtils.returnProxyIfEnabled().address().toString());
+		assertEquals(Proxy.Type.HTTP,HttpUtils.returnProxyIfEnabled().type());
+	}
+	
+	@Test
+	public void testReturnProxyIfProxyHasInvalidUrl() {
+		System.setProperty("HTTP_PROXY","104.207.145.113");
+		System.clearProperty("ALL_PROXY");
+		assertNull(HttpUtils.returnProxyIfEnabled());
+	}
+	
+	@Test
+	public void testReturnProxyIfProxyHasInvalidUrlWithoutPort() {
+		System.setProperty("HTTP_PROXY","http104.207.145.113");
+		System.clearProperty("ALL_PROXY");
+		assertNull(HttpUtils.returnProxyIfEnabled());
+	}
+}


### PR DESCRIPTION
Just added proxy support in HttpUtils class. It will allow users to use this framework when they are within corporate network.

Adding a test case as well but have disabled it because public proxy URL might change.

To use proxy, user just have to set any of following environment variable:

HTTP_PROXY, http_proxy, ALL_PROXY, all_proxy

These variables are used by default in LINUX/MAC environment (command line). When running from eclipse, users should set this variable explicitly.

