### PR TITLE
fix bug on WINDOWS: hadoop_home variable not detected

### DIFF
--- a/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/util/WindowsLibsUtils.java
+++ b/hadoop-mini-clusters-common/src/main/java/com/github/sakserv/minicluster/util/WindowsLibsUtils.java
@@ -32,7 +32,11 @@ public class WindowsLibsUtils {
 
         if(System.getProperty("HADOOP_HOME") != null) {
             return System.getProperty("HADOOP_HOME");
-        } else {
+        }
+        else if(System.getenv("HADOOP_HOME") != null){
+            return System.getenv("HADOOP_HOME");
+        }
+        else {
 
             File windowsLibDir = new File("." + Path.SEPARATOR + "windows_libs" +
                     Path.SEPARATOR + System.getProperty("hdp.release.version"));


### PR DESCRIPTION
ERROR: Could not find windows native libs when hadoop_home variable is defined
While starting dfsMiniCluster for my tests, the method getHadoopHome doesn't detect my hadoop home path even if it is set in my system. Got around this error using System.getenv("HADOOP_HOME") insteed of System.getProperty("HADOOP_HOME")
