### PR TITLE
Bump HDP version to 2.6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Using:
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-common</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 
@@ -54,7 +54,8 @@ Profile Support:
 ----------------
 Multiple versions of HDP are available. The current list is:
 
-*   HDP 2.6.2.0 (default)
+*   HDP 2.6.3.0 (default) 
+*   HDP 2.6.2.0
 *   HDP 2.6.1.0
 *   HDP 2.6.0.3
 *   HDP 2.5.3.0
@@ -80,7 +81,7 @@ Examples:
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-hdfs</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -103,7 +104,7 @@ hdfsLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-yarn</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -128,7 +129,7 @@ yarnLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-mapreduce</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -152,7 +153,7 @@ mrLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-hbase</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -183,7 +184,7 @@ hbaseLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-zookeeper</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -207,7 +208,7 @@ zookeeperLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-hiveserver2</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -231,7 +232,7 @@ hiveLocalServer2.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-hivemetastore</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -252,7 +253,7 @@ hiveLocalMetaStore.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-storm</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -272,7 +273,7 @@ stormLocalCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-kafka</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -293,7 +294,7 @@ kafkaLocalBroker.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-oozie</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -330,7 +331,7 @@ oozieLocalServer.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-mongodb</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -347,7 +348,7 @@ mongodbLocalServer.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-activemq</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -368,7 +369,7 @@ amq.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-hyperscaledb</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -390,7 +391,7 @@ hsqldbLocalServer.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-knox</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java
@@ -429,7 +430,7 @@ knoxCluster.start();
 <dependency>
     <groupId>com.github.sakserv</groupId>
     <artifactId>hadoop-mini-clusters-kdc</artifactId>
-    <version>0.1.14</version>
+    <version>0.1.15</version>
 </dependency>
 ```
 ```Java

--- a/hadoop-mini-clusters-knox/src/main/java/com/github/sakserv/minicluster/impl/LocalGatewayConfig.java
+++ b/hadoop-mini-clusters-knox/src/main/java/com/github/sakserv/minicluster/impl/LocalGatewayConfig.java
@@ -32,6 +32,7 @@ public class LocalGatewayConfig extends Configuration implements GatewayConfig {
     private static final String CRYPTO_ITERATION_COUNT = GATEWAY_CONFIG_FILE_PREFIX + ".crypto.iteration.count";
     private static final String CRYPTO_KEY_LENGTH = GATEWAY_CONFIG_FILE_PREFIX + ".crypto.key.length";
     public static final String SERVER_HEADER_ENABLED = GATEWAY_CONFIG_FILE_PREFIX + ".server.header.enabled";
+    public static final String CLIENT_AUTH_WANTED = GATEWAY_CONFIG_FILE_PREFIX + ".client.auth.wanted";
 
     public LocalGatewayConfig() {
         super(false);
@@ -483,6 +484,11 @@ public class LocalGatewayConfig extends Configuration implements GatewayConfig {
     @Override
     public boolean isGatewayServerHeaderEnabled() {
         return Boolean.parseBoolean(getVar(SERVER_HEADER_ENABLED, "true"));
+    }
+
+    @Override
+    public boolean isClientAuthWanted() {
+        return Boolean.parseBoolean(getVar(CLIENT_AUTH_WANTED, "false"));
     }
 
     /**

--- a/hadoop-mini-clusters-oozie/src/main/resources/sharelib.properties
+++ b/hadoop-mini-clusters-oozie/src/main/resources/sharelib.properties
@@ -1,3 +1,4 @@
+2.6.3.0.url=http://s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.3.0/tars/oozie/oozie-4.2.0.2.6.3.0-235-distro.tar.gz
 2.6.2.0.url=http://s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.2.0/tars/oozie/oozie-4.2.0.2.6.2.0-205-distro.tar.gz
 2.6.1.0.url=http://s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.1.0/tars/oozie/oozie-4.2.0.2.6.1.0-129-distro.tar.gz
 2.6.0.3.url=http://s3.amazonaws.com/public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.0.3/tars/oozie/oozie-4.2.0.2.6.0.3-8-distro.tar.gz

--- a/pom.xml
+++ b/pom.xml
@@ -109,15 +109,15 @@
         <httpclient.version>4.5.2</httpclient.version>
 
         <!-- Maven Release Plugin doesn't work correctly with properties defined in profiles, duplicate here -->
-        <hdp.release.version>2.6.2.0</hdp.release.version>
-        <storm.version>1.1.0.2.6.2.0-205</storm.version>
-        <hive.version>1.2.1000.2.6.2.0-205</hive.version>
-        <hadoop.version>2.7.3.2.6.2.0-205</hadoop.version>
-        <hbase.version>1.1.2.2.6.2.0-205</hbase.version>
-        <kafka.version>0.10.1.2.6.2.0-205</kafka.version>
+        <hdp.release.version>2.6.3.0</hdp.release.version>
+        <storm.version>1.1.0.2.6.3.0-235</storm.version>
+        <hive.version>1.2.1000.2.6.3.0-235</hive.version>
+        <hadoop.version>2.7.3.2.6.3.0-235</hadoop.version>
+        <hbase.version>1.1.2.2.6.3.0-235</hbase.version>
+        <kafka.version>0.10.1.2.6.3.0-235</kafka.version>
         <kafka.artifactid.version>kafka_2.10</kafka.artifactid.version>
-        <oozie.version>4.2.0.2.6.2.0-205</oozie.version>
-        <knox.version>0.12.0.2.6.2.0-205</knox.version>
+        <oozie.version>4.2.0.2.6.3.0-235</oozie.version>
+        <knox.version>0.12.0.2.6.3.0-235</knox.version>
 
     </properties>
 
@@ -126,6 +126,22 @@
         <!--
             Build profiles to use different versions of Hadoop
         -->
+
+        <!-- HDP 2.6.3.0 -->
+        <profile>
+            <id>2.6.3.0</id>
+            <properties>
+                <hdp.release.version>2.6.3.0</hdp.release.version>
+                <storm.version>1.1.0.2.6.3.0-235</storm.version>
+                <hive.version>1.2.1000.2.6.3.0-235</hive.version>
+                <hadoop.version>2.7.3.2.6.3.0-235</hadoop.version>
+                <hbase.version>1.1.2.2.6.3.0-235</hbase.version>
+                <kafka.version>0.10.1.2.6.3.0-235</kafka.version>
+                <kafka.artifactid.version>kafka_2.10</kafka.artifactid.version>
+                <oozie.version>4.2.0.2.6.3.0-235</oozie.version>
+                <knox.version>0.12.0.2.6.3.0-235</knox.version>
+            </properties>
+        </profile>
 
         <!-- HDP 2.6.2.0 -->
         <profile>


### PR DESCRIPTION
For components versions I based on http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.3.0/build_metadata.txt

Only com.github.sakserv.minicluster.impl.LocalGatewayConfig requires changes. 

@sakserv I cannot find any contribution dock.